### PR TITLE
Updated the docs to use PNPM instead of NPM because there were errors…

### DIFF
--- a/pages/setup-dev-environment.mdx
+++ b/pages/setup-dev-environment.mdx
@@ -67,10 +67,10 @@ Go to the frontend folder
 cd apps/web
 ```
 
-This will install all the dependencies needed for the frontend
+This will install all the dependencies needed for the frontend, and for this you will need [pnpm](https://pnpm.io/).
 
 ```shell copy
-npm i
+pnpm i
 ```
 
 Add an .env file in the front folder with the following content
@@ -92,7 +92,7 @@ NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000
 Run the dev environment
 
 ```shell copy
-npm run dev
+pnpm run dev
 ```
 
 ### Get to the install page


### PR DESCRIPTION
When I was trying to install the website I was getting an error when using the command `npm i` and I was later told to use `pnpm i` and that worked perfectly, so I just wanted to update the docs really quick with this small change.