### PR TITLE
chore: container disclaimer, add missing env for smooth setup

### DIFF
--- a/pages/self-hosting/hosting-guide.mdx
+++ b/pages/self-hosting/hosting-guide.mdx
@@ -17,6 +17,7 @@ Interested in helping test on Windows? Join our [Discord](https://discord.com/in
 ## Prerequisites
 
 - [Docker](https://docs.docker.com/get-docker/)
+- At least 4 GB of RAM allocated to the container runtime
 
 ## Step by step
 

--- a/pages/setup-dev-environment.mdx
+++ b/pages/setup-dev-environment.mdx
@@ -32,7 +32,7 @@ cd learnhouse
 
 <Callout type="warning">
   Make sure your container runtime has at least 4GB of RAM allocated, as default
-  settings may vary by tool.
+  settings may vary by tool
 </Callout>
 
 This will build & run the backend and the database docker images
@@ -104,24 +104,27 @@ This will install all the dependencies needed for the frontend, and for this you
 pnpm i
 ```
 
-Add an .env file in the front folder with the following content
+Add an .env file in the frontend folder with the following content
 
-```env filename="apps/web/.env" {1-2}
+<Callout type="warning">
+  Setting MultiOrg to true won't work locally for now, please keep it false
+</Callout>
+
+```env filename="apps/web/.env" {1-2} copy
 NEXT_PUBLIC_LEARNHOUSE_MULTI_ORG=false
-NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=test
+NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=defaultorg
 NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1/
 NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL=http://localhost:1338/
 NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000
 NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN=localhost
+NEXT_PUBLIC_LEARNHOUSE_COLLABORATION_WS_URL=wss://localhost:1998
+NEXTAUTH_SECRET="my-very-secret-key" 
+NEXTAUTH_URL=http://localhost:3000/
 ```
 
-<Callout type="warning">
-  Setting MultiOrg to true won't work locally for now, please set it to false
-</Callout>
-
 <Callout type="info">
-  To learn about Organizations Hosting modes, please refer to the [Organization
-  Hosting Modes](/self-hosting/organization-hosting-modes) documentation
+  For details on organization hosting, see [Organization
+  Hosting Modes](/self-hosting/organization-hosting-modes)
 </Callout>
 
 Run the dev environment
@@ -129,24 +132,6 @@ Run the dev environment
 ```shell copy
 pnpm run dev
 ```
-
-### Configure your Organization as the default one
-
-Copy this content to the .env file in the web folder
-
-```env filename="apps/web/.env" {2}
-NEXT_PUBLIC_LEARNHOUSE_MULTI_ORG=false
-NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=default
-NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1/
-NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL=http://localhost:1338/
-NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000
-NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN=localhost
-NEXT_PUBLIC_LEARNHOUSE_COLLABORATION_WS_URL=wss://localhost:1998
-```
-
-Make sure to change the `NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG` to the organization you want to set as the default one, you'll find the organization slug in the database in the `organizations` table
-
-Here it is set to `default` which is the default organization created by the backend when you ran the backend in the previous steps
 
 ### Congratulations, you're done! 🎉
 

--- a/pages/setup-dev-environment.mdx
+++ b/pages/setup-dev-environment.mdx
@@ -112,7 +112,7 @@ Add an .env file in the frontend folder with the following content
 
 ```env filename="apps/web/.env" {1-2} copy
 NEXT_PUBLIC_LEARNHOUSE_MULTI_ORG=false
-NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=defaultorg
+NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=default
 NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1/
 NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL=http://localhost:1338/
 NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000

--- a/pages/setup-dev-environment.mdx
+++ b/pages/setup-dev-environment.mdx
@@ -30,6 +30,11 @@ cd learnhouse
 
 ### Build & install LearnHouse
 
+<Callout type="warning">
+  Make sure your container runtime has at least 4GB of RAM allocated, as default
+  settings may vary by tool.
+</Callout>
+
 This will build & run the backend and the database docker images
 
 ```shell copy
@@ -70,7 +75,10 @@ poetry install
 poetry run python app.py
 ```
 
-<Callout type="info">To learn more about Configuration options, please refer to the [Configuration](/self-hosting/configuration) documentation</Callout>
+<Callout type="info">
+  To learn more about Configuration options, please refer to the
+  [Configuration](/self-hosting/configuration) documentation
+</Callout>
 
 #### Check the API
 
@@ -104,12 +112,16 @@ NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=test
 NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1/
 NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL=http://localhost:1338/
 NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000
+NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN=localhost
 ```
 
-<Callout type="warning">Setting MultiOrg to true won't work locally for now, please set it to false</Callout>
+<Callout type="warning">
+  Setting MultiOrg to true won't work locally for now, please set it to false
+</Callout>
 
 <Callout type="info">
-  To learn about Organizations Hosting modes, please refer to the [Organization Hosting Modes](/self-hosting/organization-hosting-modes) documentation
+  To learn about Organizations Hosting modes, please refer to the [Organization
+  Hosting Modes](/self-hosting/organization-hosting-modes) documentation
 </Callout>
 
 Run the dev environment
@@ -128,10 +140,11 @@ NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG=default
 NEXT_PUBLIC_LEARNHOUSE_API_URL=http://localhost:1338/api/v1/
 NEXT_PUBLIC_LEARNHOUSE_BACKEND_URL=http://localhost:1338/
 NEXT_PUBLIC_LEARNHOUSE_DOMAIN=localhost:3000
+NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN=localhost
 NEXT_PUBLIC_LEARNHOUSE_COLLABORATION_WS_URL=wss://localhost:1998
 ```
 
-Make sure to change the `NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG` to the organization you want to set as the default one, you''l find the organization slug in the database in the `organizations` table
+Make sure to change the `NEXT_PUBLIC_LEARNHOUSE_DEFAULT_ORG` to the organization you want to set as the default one, you'll find the organization slug in the database in the `organizations` table
 
 Here it is set to `default` which is the default organization created by the backend when you ran the backend in the previous steps
 
@@ -143,9 +156,8 @@ Visit the app at [http://localhost:3000/](http://localhost:3000/)
 
 ## Next Steps
 
-Thanks for contributing to LearnHouse 💟 
+Thanks for contributing to LearnHouse 💟
 
-You'll find here some issues/ features we need help with, feel free to contribute to any of them 
+You'll find here some issues/ features we need help with, feel free to contribute to any of them
 
 - [Help Wanted Issues](https://github.com/learnhouse/learnhouse/labels/help%20wanted)
-


### PR DESCRIPTION
Related to PR [#334](https://github.com/learnhouse/learnhouse/pull/334)

Changes:
1. Added container memory disclaimer to the docs to help circumvent build failures when compiling the frontend. [#392](https://github.com/learnhouse/learnhouse/issues/329)

2. Added the `NEXT_PUBLIC_LEARNHOUSE_TOP_DOMAIN` to the env sections.

Reason for the second change was I noticed that without this NextJS auth cookies would try to default to being secure, which won't work for `localhost`