### PR TITLE
docs: update login url

### DIFF
--- a/pages/self-hosting/hosting-guide.mdx
+++ b/pages/self-hosting/hosting-guide.mdx
@@ -69,7 +69,7 @@ When running the application for the first time, an admin account and organizati
 
 #### Login to your account 
 
-Open your browser and go to [http://localhost/login](http://localhost/login) to access the application.
+Open your browser and go to [http://localhost/login?orgslug=default](http://localhost/login?orgslug=default) to access the application.
 
 #### Change your password
 


### PR DESCRIPTION
Based on discussion on Discord https://discord.com/channels/1107343767217913917/1398520167306231949

Accessing the login page without specifying `orgslug` leads to an error in recent builds. Updated url to: http://localhost/login?orgslug=default

<img width="1138" height="470" alt="image" src="https://github.com/user-attachments/assets/9393ab97-299c-44ed-b257-a61cb9526d12" />
