### PR TITLE
fix: update activity links to include 'content' path

### DIFF
--- a/pages/features/content/courses.mdx
+++ b/pages/features/content/courses.mdx
@@ -16,17 +16,17 @@ There is a wide variety of Activities types to choose from, and we are constantl
 <Card icon={<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
   <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
 </svg>
-  } title="Videos" href="/features/activities/videos">
+  } title="Videos" href="/features/content/activities/videos">
   </Card>
   <Card icon={<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
   <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
 </svg>
-  } title="Dynamic Pages" href="/features/activities/dynamic-pages">
+  } title="Dynamic Pages" href="/features/content/activities/dynamic-pages">
   </Card>
   <Card icon={<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
   <path strokeLinecap="round" strokeLinejoin="round" d="M21 7.5l-9-5.25L3 7.5m18 0l-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9" />
 </svg>
-  } title="Documents" href="/features/activities/documents">
+  } title="Documents" href="/features/content/activities/documents">
   </Card>
 </Cards>
 


### PR DESCRIPTION
Fixes #86 

### Summary

Fixes incorrect activity links in the documentation.

### Details

Updates activity links (Videos, Documents, Dynamic Pages) from:

```
/features/activities/*
```

to:

```
/features/content/activities/*
```